### PR TITLE
Hide internal parameters, expose box dimensions

### DIFF
--- a/skadis.scad
+++ b/skadis.scad
@@ -1,3 +1,9 @@
+/* [Box Size] */
+width = 120;
+height = 60;
+depth = 20;
+
+/* [Hidden] */
 plate_thickness = 0; 
 clip_height     = 12;
 gap_x           = 40;
@@ -77,4 +83,4 @@ module front_box_on_plate(width, height, depth, wall=2, bottom=3) {
   }
 }
 
-skadis_box(width=120, height=60, depth=20, wall=2, bottom=3);
+skadis_box(width=width, height=height, depth=depth);


### PR DESCRIPTION
Simplify the `skadis_box` Customizer by exposing only `width`, `height`, and `depth`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c850bece-4705-42c2-a6d3-2758217253a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c850bece-4705-42c2-a6d3-2758217253a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

