### PR TITLE
Add user-specified engraving text

### DIFF
--- a/skadis.scad
+++ b/skadis.scad
@@ -109,7 +109,8 @@ module add_front_text_emboss(width, height, depth) {
   // Start slightly inside the front face and extrude outward (+Y)
   translate([0, plate_thickness/2 + depth - text_epsilon, height/2])
     rotate([-90, 0, 0])
-      front_text_geometry(engrave_depth + 2*text_epsilon);
+      rotate([0, 0, 180])
+        front_text_geometry(engrave_depth + 2*text_epsilon);
 }
 
 // Place engraved (recessed) text volume to subtract from the front face

--- a/skadis.scad
+++ b/skadis.scad
@@ -21,6 +21,7 @@ engrave_depth = 0.8;           // Depth/height of text (mm). Used for both engra
 engrave_font  = "";           // Example: "Liberation Sans:style=Bold"; empty uses OpenSCAD default
 text_emboss   = false;         // If true, text is embossed (raised). If false, engraved (recessed)
 text_round_radius = 0.3;       // Rounds glyph corners (mm) to avoid sharp edges
+text_epsilon = 0.1;            // Small overlap (mm) to avoid coplanar CSG issues
 
 module skadis_box(width=120, height=160, depth=60, wall=2, bottom=3, fillet_radius=0) {
   back_plate_with_clips(width=width, height=height);
@@ -105,7 +106,7 @@ module front_text_geometry(depth_amount) {
 
 // Place embossed (raised) text on the front face
 module add_front_text_emboss(width, height, depth) {
-  translate([0, plate_thickness/2 + depth, height/2])
+  translate([0, plate_thickness/2 + depth + text_epsilon, height/2])
     rotate([90, 0, 0])
       front_text_geometry(engrave_depth);
 }
@@ -113,8 +114,8 @@ module add_front_text_emboss(width, height, depth) {
 // Place engraved (recessed) text volume to subtract from the front face
 module subtract_front_text_engrave(width, height, depth, wall) {
   fd = min(engrave_depth, max(wall - 0.2, 0.1));
-  translate([0, plate_thickness/2 + depth - fd, height/2])
-    rotate([90, 0, 0])
+  translate([0, plate_thickness/2 + depth - fd - text_epsilon, height/2])
+    rotate([-90, 0, 0])
       front_text_geometry(fd);
 }
 

--- a/skadis.scad
+++ b/skadis.scad
@@ -99,7 +99,8 @@ module engrave_front_text(width, height, depth, wall) {
     translate([0, plate_thickness/2 + depth + 0.01, height/2])
       rotate([90, 0, 0])
         linear_extrude(height=engraving_depth)
-          text(text=engrave_text, size=engrave_size, font=engrave_font, halign="center", valign="center");
+          mirror([1,0,0])
+            text(text=engrave_text, size=engrave_size, font=engrave_font, halign="center", valign="center");
   }
 }
 

--- a/skadis.scad
+++ b/skadis.scad
@@ -106,17 +106,19 @@ module front_text_geometry(depth_amount) {
 
 // Place embossed (raised) text on the front face
 module add_front_text_emboss(width, height, depth) {
-  translate([0, plate_thickness/2 + depth + text_epsilon, height/2])
-    rotate([90, 0, 0])
-      front_text_geometry(engrave_depth);
+  // Start slightly inside the front face and extrude outward (+Y)
+  translate([0, plate_thickness/2 + depth - text_epsilon, height/2])
+    rotate([-90, 0, 0])
+      front_text_geometry(engrave_depth + 2*text_epsilon);
 }
 
 // Place engraved (recessed) text volume to subtract from the front face
 module subtract_front_text_engrave(width, height, depth, wall) {
   fd = min(engrave_depth, max(wall - 0.2, 0.1));
-  translate([0, plate_thickness/2 + depth - fd - text_epsilon, height/2])
-    rotate([-90, 0, 0])
-      front_text_geometry(fd);
+  // Start slightly outside the front face and extrude inward (-Y)
+  translate([0, plate_thickness/2 + depth + text_epsilon, height/2])
+    rotate([90, 0, 0])
+      front_text_geometry(fd + 2*text_epsilon);
 }
 
 module front_box_on_plate(width, height, depth, wall=2, bottom=3, fillet_radius=0) {

--- a/skadis.scad
+++ b/skadis.scad
@@ -96,21 +96,19 @@ module rounded_rect_2d(w, d, r) {
 // Text geometry helper: rounded glyphs extruded along +Y in local space
 module front_text_geometry(depth_amount) {
   linear_extrude(height=depth_amount)
-    mirror([1,0,0])
-      if (text_round_radius > 0)
-        offset(r=text_round_radius)
-          text(text=engrave_text, size=engrave_size, font=engrave_font, halign="center", valign="center");
-      else
+    if (text_round_radius > 0)
+      offset(r=text_round_radius)
         text(text=engrave_text, size=engrave_size, font=engrave_font, halign="center", valign="center");
+    else
+      text(text=engrave_text, size=engrave_size, font=engrave_font, halign="center", valign="center");
 }
 
 // Place embossed (raised) text on the front face
 module add_front_text_emboss(width, height, depth) {
   // Start slightly inside the front face and extrude outward (+Y)
   translate([0, plate_thickness/2 + depth - text_epsilon, height/2])
-    rotate([-90, 0, 0])
-      rotate([0, 0, 180])
-        front_text_geometry(engrave_depth + 2*text_epsilon);
+    rotate([90, 0, 0])
+      front_text_geometry(engrave_depth + 2*text_epsilon);
 }
 
 // Place engraved (recessed) text volume to subtract from the front face
@@ -118,7 +116,7 @@ module subtract_front_text_engrave(width, height, depth, wall) {
   fd = min(engrave_depth, max(wall - 0.2, 0.1));
   // Start slightly outside the front face and extrude inward (-Y)
   translate([0, plate_thickness/2 + depth + text_epsilon, height/2])
-    rotate([90, 0, 0])
+    rotate([-90, 0, 0])
       front_text_geometry(fd + 2*text_epsilon);
 }
 

--- a/skadis.scad
+++ b/skadis.scad
@@ -96,7 +96,10 @@ module rounded_rect_2d(w, d, r) {
 module front_text_geometry(depth_amount) {
   linear_extrude(height=depth_amount)
     mirror([1,0,0])
-      offset(r=text_round_radius)
+      if (text_round_radius > 0)
+        offset(r=text_round_radius)
+          text(text=engrave_text, size=engrave_size, font=engrave_font, halign="center", valign="center");
+      else
         text(text=engrave_text, size=engrave_size, font=engrave_font, halign="center", valign="center");
 }
 


### PR DESCRIPTION
Adds an optional engraving feature to the front face of the Skadis box, allowing users to specify custom text.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd2ddcfb-0289-481e-be47-14c8438066d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bd2ddcfb-0289-481e-be47-14c8438066d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

