### PR TITLE
Add user-defined inscription to front panel

### DIFF
--- a/skadis.scad
+++ b/skadis.scad
@@ -127,20 +127,23 @@ module front_text_volume(width, height, depth, wall, mode="engrave") {
   // Position: front face is at y = plate_thickness/2 + depth
   y_front = plate_thickness/2 + depth;
 
-  // Position: place emboss fully outside; engrave cuts into wall and slightly crosses the front plane
-  y_pos = is_engrave ? (y_front - engr_d) : (y_front + t_eps);
-  thickness = is_engrave ? (engr_d + t_eps) : (emb_h);
+  // For engrave, push the cutter slightly through the outer face and into the wall by engr_d
+  // For emboss, start slightly inside the wall so union merges cleanly, then grow outward
+  y_pos = is_engrave ? (y_front - engr_d - t_eps) : (y_front - t_eps);
+  thickness = is_engrave ? (engr_d + 2*t_eps) : (emb_h + t_eps);
 
   translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
-    // Orient text onto front plane with extrude along +Y; mirror Z to keep text upright (not upside down)
+    // Orient text onto front plane readable from the front: extrude along -Y into the wall for engrave, and +Y for emboss.
+    // Use a fixed orientation: rotate -90 deg around X, then mirror X to correct left-right, and mirror Z to correct upside-down.
     rotate([-90, 0, 0])
-      mirror([0,0,1])
-        linear_extrude(height=thickness)
-          text(text=user_text,
-               size=user_text_size,
-               font=user_text_font,
-               halign=user_text_halign,
-               valign=user_text_valign);
+      mirror([1,0,0])
+        mirror([0,0,1])
+          linear_extrude(height=thickness)
+            text(text=user_text,
+                 size=user_text_size,
+                 font=user_text_font,
+                 halign=user_text_halign,
+                 valign=user_text_valign);}
 }
 
 module front_box_on_plate(width, height, depth, wall=2, bottom=3, fillet_radius=0) {

--- a/skadis.scad
+++ b/skadis.scad
@@ -134,19 +134,20 @@ module front_text_volume(width, height, depth, wall, mode="engrave") {
     y_pos = y_front + t_eps;
         translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
       rotate([90, 0, 0])
-        linear_extrude(height=thickness)
-          text(text=user_text,
-               size=user_text_size,
-               font=user_text_font,
-               halign=user_text_halign,
-               valign=user_text_valign);
+        rotate([0, 0, 180])
+          linear_extrude(height=thickness)
+            text(text=user_text,
+                 size=user_text_size,
+                 font=user_text_font,
+                 halign=user_text_halign,
+                 valign=user_text_valign);
   } else {
-    // Start slightly inside the wall and grow outward toward +Y
-    thickness = emb_h + t_eps;
-    y_pos = y_front - t_eps;
-        translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
-      rotate([-90, 0, 0])
-        mirror([0,0,1])
+        // Start slightly outside the face and grow outward toward +Y so it’s visible even in preview
+    thickness = emb_h + 2*t_eps;
+    y_pos = y_front + t_eps;
+    translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
+      rotate([90, 0, 0])
+        rotate([0, 0, 180])
           linear_extrude(height=thickness)
             text(text=user_text,
                  size=user_text_size,

--- a/skadis.scad
+++ b/skadis.scad
@@ -133,17 +133,15 @@ module front_text_volume(width, height, depth, wall, mode="engrave") {
   thickness = is_engrave ? (engr_d + 2*t_eps) : (emb_h + t_eps);
 
   translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
-    // Orient text onto front plane readable from the front: extrude along -Y into the wall for engrave, and +Y for emboss.
-    // Use a fixed orientation: rotate -90 deg around X, then mirror X to correct left-right, and mirror Z to correct upside-down.
+    // Orient text onto front plane readable from the front: rotate -90 deg around X, then mirror Z to keep upright (no left-right mirroring)
     rotate([-90, 0, 0])
-      mirror([1,0,0])
-        mirror([0,0,1])
-          linear_extrude(height=thickness)
-            text(text=user_text,
-                 size=user_text_size,
-                 font=user_text_font,
-                 halign=user_text_halign,
-                 valign=user_text_valign);}
+      mirror([0,0,1])
+        linear_extrude(height=thickness)
+          text(text=user_text,
+               size=user_text_size,
+               font=user_text_font,
+               halign=user_text_halign,
+               valign=user_text_valign);
 }
 
 module front_box_on_plate(width, height, depth, wall=2, bottom=3, fillet_radius=0) {

--- a/skadis.scad
+++ b/skadis.scad
@@ -132,11 +132,10 @@ module front_text_volume(width, height, depth, wall, mode="engrave") {
     // Start slightly in front of the face, cut into the wall toward -Y
     thickness = engr_d + 2*t_eps;
     y_pos = y_front + t_eps;
-    translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
+        translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
       rotate([90, 0, 0])
-        mirror([0,0,1])
-          linear_extrude(height=thickness)
-            text(text=user_text,
+        linear_extrude(height=thickness)
+          text(text=user_text,
                size=user_text_size,
                font=user_text_font,
                halign=user_text_halign,
@@ -145,10 +144,11 @@ module front_text_volume(width, height, depth, wall, mode="engrave") {
     // Start slightly inside the wall and grow outward toward +Y
     thickness = emb_h + t_eps;
     y_pos = y_front - t_eps;
-    translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
+        translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
       rotate([-90, 0, 0])
-        linear_extrude(height=thickness)
-          text(text=user_text,
+        mirror([0,0,1])
+          linear_extrude(height=thickness)
+            text(text=user_text,
                  size=user_text_size,
                  font=user_text_font,
                  halign=user_text_halign,

--- a/skadis.scad
+++ b/skadis.scad
@@ -133,15 +133,14 @@ module front_text_volume(width, height, depth, wall, mode="engrave") {
   thickness = is_engrave ? (engr_d + 2*t_eps) : (emb_h + t_eps);
 
   translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
-    // Rotate so extrude axis (Z) becomes +Y, then mirror Z after rotation to keep text upright
-    mirror([0,0,1])
-      rotate([-90, 0, 0])
-        linear_extrude(height=thickness)
-          text(text=user_text,
-               size=user_text_size,
-               font=user_text_font,
-               halign=user_text_halign,
-               valign=user_text_valign);
+    // Rotate so extrude axis (Z) becomes +Y with correct readable orientation from the front (no mirroring)
+    rotate([90, 0, 0])
+      linear_extrude(height=thickness)
+        text(text=user_text,
+             size=user_text_size,
+             font=user_text_font,
+             halign=user_text_halign,
+             valign=user_text_valign);
 }
 
 module front_box_on_plate(width, height, depth, wall=2, bottom=3, fillet_radius=0) {

--- a/skadis.scad
+++ b/skadis.scad
@@ -134,8 +134,9 @@ module front_text_volume(width, height, depth, wall, mode="engrave") {
     y_pos = y_front + t_eps;
     translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
       rotate([90, 0, 0])
-        linear_extrude(height=thickness)
-          text(text=user_text,
+        mirror([0,0,1])
+          linear_extrude(height=thickness)
+            text(text=user_text,
                size=user_text_size,
                font=user_text_font,
                halign=user_text_halign,
@@ -146,9 +147,8 @@ module front_text_volume(width, height, depth, wall, mode="engrave") {
     y_pos = y_front - t_eps;
     translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
       rotate([-90, 0, 0])
-        mirror([0,0,1])
-          linear_extrude(height=thickness)
-            text(text=user_text,
+        linear_extrude(height=thickness)
+          text(text=user_text,
                  size=user_text_size,
                  font=user_text_font,
                  halign=user_text_halign,

--- a/skadis.scad
+++ b/skadis.scad
@@ -127,14 +127,13 @@ module front_text_volume(width, height, depth, wall, mode="engrave") {
   // Position: front face is at y = plate_thickness/2 + depth
   y_front = plate_thickness/2 + depth;
 
-  // For engrave, push the cutter slightly through the outer face and into the wall by engr_d
-  // For emboss, start slightly inside the wall so union merges cleanly, then grow outward
-  y_pos = is_engrave ? (y_front - engr_d - t_eps) : (y_front - t_eps);
-  thickness = is_engrave ? (engr_d + 2*t_eps) : (emb_h + t_eps);
+  // Position: place emboss fully outside; engrave cuts into wall and slightly crosses the front plane
+  y_pos = is_engrave ? (y_front - engr_d) : (y_front + t_eps);
+  thickness = is_engrave ? (engr_d + t_eps) : (emb_h);
 
   translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
-    // Rotate so extrude axis (Z) becomes +Y with correct readable orientation from the front (no mirroring)
-    rotate([90, 0, 0])
+    // Orient text onto front plane with extrude along +Y (outward). Works for both engrave and emboss.
+    rotate([-90, 0, 0])
       linear_extrude(height=thickness)
         text(text=user_text,
              size=user_text_size,

--- a/skadis.scad
+++ b/skadis.scad
@@ -127,21 +127,33 @@ module front_text_volume(width, height, depth, wall, mode="engrave") {
   // Position: front face is at y = plate_thickness/2 + depth
   y_front = plate_thickness/2 + depth;
 
-  // For engrave, push the cutter slightly through the outer face and into the wall by engr_d
-  // For emboss, start slightly inside the wall so union merges cleanly, then grow outward
-  y_pos = is_engrave ? (y_front - engr_d - t_eps) : (y_front - t_eps);
-  thickness = is_engrave ? (engr_d + 2*t_eps) : (emb_h + t_eps);
-
-  translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
-    // Orient text onto front plane readable from the front: rotate -90 deg around X, then mirror Z to keep upright (no left-right mirroring)
-    rotate([-90, 0, 0])
-      mirror([0,0,1])
+  // Compute placement and orientation per mode
+  if (is_engrave) {
+    // Start slightly in front of the face, cut into the wall toward -Y
+    thickness = engr_d + 2*t_eps;
+    y_pos = y_front + t_eps;
+    translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
+      rotate([90, 0, 0])
         linear_extrude(height=thickness)
           text(text=user_text,
                size=user_text_size,
                font=user_text_font,
                halign=user_text_halign,
                valign=user_text_valign);
+  } else {
+    // Start slightly inside the wall and grow outward toward +Y
+    thickness = emb_h + t_eps;
+    y_pos = y_front - t_eps;
+    translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
+      rotate([-90, 0, 0])
+        mirror([0,0,1])
+          linear_extrude(height=thickness)
+            text(text=user_text,
+                 size=user_text_size,
+                 font=user_text_font,
+                 halign=user_text_halign,
+                 valign=user_text_valign);
+  }
 }
 
 module front_box_on_plate(width, height, depth, wall=2, bottom=3, fillet_radius=0) {

--- a/skadis.scad
+++ b/skadis.scad
@@ -15,8 +15,9 @@ HS              = 1000;
 wall_fillet_radius = 0; // set > 0 to enable wall fillet
 
 /* [Front Text] */
-user_text = "";                   // leave empty to disable text
-user_text_mode = "none";          // one of: "none", "engrave", "emboss"
+user_text_enabled = false;
+user_text = "";                   // leave empty to disable text when not enabled
+user_text_mode = "engrave";          // ["engrave","emboss"]
 user_text_size = 14;               // text point size
 user_text_depth = 0.8;             // engraving depth (into the wall)
 user_text_height = 1.2;            // embossing height (out of the wall)
@@ -33,7 +34,7 @@ module skadis_box(width=120, height=160, depth=60, wall=2, bottom=3, fillet_radi
     front_box_on_plate(width=width, height=height, depth=depth, wall=wall, bottom=bottom, fillet_radius=fillet_radius);
   }
 
-  has_text = (len(user_text) > 0) && (user_text_mode != "none");
+  has_text = user_text_enabled && (len(user_text) > 0);
 
   if (has_text && user_text_mode == "engrave") {
     difference() {
@@ -129,14 +130,15 @@ module front_text_volume(width, height, depth, wall, mode="engrave") {
   y_pos = is_engrave ? (y_front - thickness) : y_front;
 
   translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
-    // Rotate so extrude axis (Z) becomes +Y, keeping X and Z for layout
+    // Rotate so extrude axis (Z) becomes +Y, then mirror Z to keep text upright
     rotate([-90, 0, 0])
-      linear_extrude(height=thickness)
-        text(text=user_text,
-             size=user_text_size,
-             font=user_text_font,
-             halign=user_text_halign,
-             valign=user_text_valign);
+      mirror([0,0,1])
+        linear_extrude(height=thickness)
+          text(text=user_text,
+               size=user_text_size,
+               font=user_text_font,
+               halign=user_text_halign,
+               valign=user_text_valign);
 }
 
 module front_box_on_plate(width, height, depth, wall=2, bottom=3, fillet_radius=0) {

--- a/skadis.scad
+++ b/skadis.scad
@@ -132,14 +132,15 @@ module front_text_volume(width, height, depth, wall, mode="engrave") {
   thickness = is_engrave ? (engr_d + t_eps) : (emb_h);
 
   translate([user_text_offset_x, y_pos, height/2 + user_text_offset_z])
-    // Orient text onto front plane with extrude along +Y (outward). Works for both engrave and emboss.
+    // Orient text onto front plane with extrude along +Y; mirror Z to keep text upright (not upside down)
     rotate([-90, 0, 0])
-      linear_extrude(height=thickness)
-        text(text=user_text,
-             size=user_text_size,
-             font=user_text_font,
-             halign=user_text_halign,
-             valign=user_text_valign);
+      mirror([0,0,1])
+        linear_extrude(height=thickness)
+          text(text=user_text,
+               size=user_text_size,
+               font=user_text_font,
+               halign=user_text_halign,
+               valign=user_text_valign);
 }
 
 module front_box_on_plate(width, height, depth, wall=2, bottom=3, fillet_radius=0) {


### PR DESCRIPTION
Adds user-defined text to the front wall of the Skadis box, with options for engraving or embossing.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa54bf32-7204-45ba-ad50-983167c5829a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fa54bf32-7204-45ba-ad50-983167c5829a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

