### PR TITLE
Add customizable front engraving text

### DIFF
--- a/skadis.scad
+++ b/skadis.scad
@@ -104,26 +104,22 @@ module front_text_shape(width, height, depth, is_embossed=false) {
     y_front = plate_thickness/2 + depth;
     eps = 0.02;
 
-    // Common 2D glyph (in XY), rotated in-plane first
-    module glyph2d() {
-      rotate([0, 0, front_text_rotation])
-        text(front_text, size=front_text_size, font=front_text_font, halign=front_text_halign, valign=front_text_valign, spacing=front_text_spacing);
-    }
 
     if (is_embossed) {
-      // Place slightly intersecting the front face and extrude outward (+Y)
-      translate([front_text_offset_x, y_front - eps, (height/2) + front_text_offset_z])
-        // Apply +90 then extra 180 around X as requested; net keeps outward extrusion and flips appearance
-        rotate([180, 0, 0])
-          rotate([90, 0, 0])
-            linear_extrude(height=front_text_depth)
-              glyph2d();
+      // Emboss: start just outside the front face and extrude inward (net union creates outside bump)
+      translate([front_text_offset_x, y_front + eps, (height/2) + front_text_offset_z])
+        // Rotate 180° around X as requested; total 270° to keep front-face orientation while flipping glyph
+        rotate([270, 0, 0])
+          linear_extrude(height=front_text_depth)
+            rotate([0, 0, front_text_rotation])
+              text(front_text, size=front_text_size, font=front_text_font, halign=front_text_halign, valign=front_text_valign, spacing=front_text_spacing);
     } else {
       // Engrave: start slightly outside and cut inward (-Y) so it is visible on the surface
       translate([front_text_offset_x, y_front + eps, (height/2) + front_text_offset_z])
         rotate([90, 0, 0])
           linear_extrude(height=front_text_depth)
-            glyph2d();
+            rotate([0, 0, front_text_rotation])
+              text(front_text, size=front_text_size, font=front_text_font, halign=front_text_halign, valign=front_text_valign, spacing=front_text_spacing);
     }
   }
 }


### PR DESCRIPTION
Enable user-specified engraved or embossed text on the front face.

---
<a href="https://cursor.com/background-agent?bcId=bc-c71cce73-4057-4603-93fa-c76ed2138b98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c71cce73-4057-4603-93fa-c76ed2138b98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

